### PR TITLE
Allow overriding pinot image tag in helm chart

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -171,7 +171,7 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Docker image to use
+Docker image to use for service manager
 */}}
 {{- define "pinot.servicemanager.image" -}}
   {{- if and .Values.servicemanager.image.repository .Values.servicemanager.image.tag -}}
@@ -179,6 +179,17 @@ Docker image to use
     {{- if .Values.servicemanager.image.sha256 -}}
       {{- printf "@sha256:%s" .Values.servicemanager.image.sha256 }}
     {{- end -}}
+  {{- else -}}
+    {{- printf "%s:%s" .Values.image.repository .Chart.Version }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Docker image to use for controller, broker and server
+*/}}
+{{- define "pinot.image" -}}
+  {{- if and .Values.image.tagOverride  -}}
+    {{- printf "%s:%s" .Values.image.repository .Values.image.tagOverride }}
   {{- else -}}
     {{- printf "%s:%s" .Values.image.repository .Chart.Version }}
   {{- end -}}

--- a/helm/templates/broker/statefulset.yml
+++ b/helm/templates/broker/statefulset.yml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: pinot-broker
-          image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
+          image: {{ include "pinot.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: [
             "StartBroker",

--- a/helm/templates/controller/statefulset.yaml
+++ b/helm/templates/controller/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
       {{- end }}
       containers:
         - name: pinot-controller
-          image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
+          image: {{ include "pinot.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: [ "StartController", "-configFileName", "/var/pinot/controller/config/pinot-controller.conf" ]
           env:

--- a/helm/templates/server/statefulset.yml
+++ b/helm/templates/server/statefulset.yml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: pinot-server
-          image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
+          image: {{ include "pinot.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: [
             "StartServer",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,6 +4,7 @@ nameOverride: ""
 image:
   repository: hypertrace/pinot
   pullPolicy: IfNotPresent
+  tagOverride: ""
 
 imagePullSecrets: []
 


### PR DESCRIPTION
This will allow us to override both repository and tag of docker image to deploy.