### PR TITLE
Remove trigger tag after publishing the helm chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,6 @@ jobs:
       - setup_build_environment
       - gradle:
           args: :tag
-      - run:
-          name: Remove trigger tag
-          command: git tag -d release-$(git describe --abbrev=0)
       - gradle:
           args: dockerPushImages
       - add_ssh_keys:
@@ -84,7 +81,7 @@ jobs:
             - '51:2e:8c:f6:b6:7b:ac:ac:cc:1b:b8:39:3d:82:e5:38'
       - run:
           name: Update remote tags
-          command: git push origin :refs/tags/release-$(git describe --abbrev=0) refs/tags/$(git describe --abbrev=0)
+          command: git push origin refs/tags/$(git describe --abbrev=0)
   validate-charts:
     executor: helm
     steps:
@@ -99,6 +96,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Remove trigger tag
+          command: git tag -d release-$(git describe --abbrev=0)
+      - run:
           name: Package and Publish Helm Charts
           # Read the "name:" from Chart.yaml. The chart version is <chart-name>-<semver git tag>
           command: |
@@ -109,6 +109,12 @@ jobs:
             helm repo add helm-gcs ${HELM_GCS_REPOSITORY}
             helm package --version ${CHART_VERSION} --app-version ${CHART_VERSION} ./helm/
             helm gcs push ${CHART_NAME}-${CHART_VERSION}.tgz helm-gcs --public --retry
+      - add_ssh_keys:
+          fingerprints:
+            - '51:2e:8c:f6:b6:7b:ac:ac:cc:1b:b8:39:3d:82:e5:38'
+      - run:
+          name: Update remote tags
+          command: git push origin :refs/tags/release-$(git describe --abbrev=0)
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,9 @@ jobs:
       - setup_build_environment
       - gradle:
           args: :tag
+      - run:
+          name: Remove trigger tag
+          command: git tag -d release-$(git describe --abbrev=0)
       - gradle:
           args: dockerPushImages
       - add_ssh_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,18 +73,7 @@ jobs:
     steps:
       - setup_build_environment
       - gradle:
-          args: :tag
-      - run:
-          name: Remove trigger tag
-          command: git tag -d release-$(git describe --abbrev=0)
-      - gradle:
           args: dockerPushImages
-      - add_ssh_keys:
-          fingerprints:
-            - '51:2e:8c:f6:b6:7b:ac:ac:cc:1b:b8:39:3d:82:e5:38'
-      - run:
-          name: Update remote tags
-          command: git push origin refs/tags/$(git describe --abbrev=0)
   validate-charts:
     executor: helm
     steps:
@@ -98,6 +87,9 @@ jobs:
     executor: helm
     steps:
       - checkout
+      - run:
+          name: Add release tag
+          command: git tag -am "Released by $CIRCLE_USERNAME" $(git describe --abbrev=0 --tags | sed 's/^release-//')
       - run:
           name: Remove trigger tag
           command: git tag -d release-$(git describe --abbrev=0)
@@ -117,7 +109,7 @@ jobs:
             - '51:2e:8c:f6:b6:7b:ac:ac:cc:1b:b8:39:3d:82:e5:38'
       - run:
           name: Update remote tags
-          command: git push origin :refs/tags/release-$(git describe --abbrev=0)
+          command: git push origin refs/tags/$(git describe --abbrev=0) :refs/tags/release-$(git describe --abbrev=0)
 
 workflows:
   version: 2


### PR DESCRIPTION
`release-charts step` in circleci workflow failed while releasing new version of pinot:
```
Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but the behavior may be different from official git. If this is an issue, please use an image that has official git and ssh installed.
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Compressing objects: 100% (9/9), done.
Total 189 (delta 0), reused 9 (delta 0), pack-reused 180

reference not found
```