### PR TITLE
set git config before adding a release tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,10 @@ jobs:
       - checkout
       - run:
           name: Add release tag
-          command: git tag -am "Released by $CIRCLE_USERNAME" $(git describe --abbrev=0 --tags | sed 's/^release-//')
+          command: |
+            git config --global user.email "${CIRCLE_USERNAME}@hypertrace.org"
+            git config --global user.name "$CIRCLE_USERNAME"
+            git tag -am "Released by $CIRCLE_USERNAME" $(git describe --abbrev=0 --tags | sed 's/^release-//')
       - run:
           name: Remove trigger tag
           command: git tag -d release-$(git describe --abbrev=0)


### PR DESCRIPTION
fixes circleci issue:
```
#!/bin/sh -eo pipefail
git tag -am "Released by $CIRCLE_USERNAME" $(git describe --abbrev=0 --tags | sed 's/^release-//')

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'root@88789f782dd3.(none)')

Exited with code exit status 128
CircleCI received exit code 128
```