### PR TITLE
update helm-gcs-packager image version in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
       - image: cimg/openjdk:14.0.2
   helm:
     docker:
-      - image: hypertrace/helm-gcs-packager:0.2.0
+      - image: hypertrace/helm-gcs-packager:0.3.0
 
 commands:
   gradle:


### PR DESCRIPTION
updated image version has `openssh-client` package installed. This will fix the following error in circleci:
```
#!/bin/sh -eo pipefail
git push origin refs/tags/$(git describe --abbrev=0) :refs/tags/release-$(git describe --abbrev=0)
error: cannot run ssh: No such file or directory
fatal: unable to fork

Exited with code exit status 128
CircleCI received exit code 128
```