### PR TITLE
Doubles health check timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,7 @@ jobs:
             helm gcs push ${CHART_NAME}-${CHART_VERSION}.tgz helm-gcs --public --retry
       - add_ssh_keys:
           fingerprints:
+            # This ssh key gives write permission needed for the following step.
             - '51:2e:8c:f6:b6:7b:ac:ac:cc:1b:b8:39:3d:82:e5:38'
       - run:
           name: Update remote tags

--- a/pinot-servicemanager/Dockerfile
+++ b/pinot-servicemanager/Dockerfile
@@ -45,6 +45,7 @@ COPY --from=install --chown=${USER} /install .
 EXPOSE 9000 8099 8098 8097 8096 9514 7098
 
 # We use start period of 45s to avoid marking Pinot unhealthy on slow or contended CI hosts
-HEALTHCHECK --interval=1s --start-period=45s --timeout=5s --retries=15 CMD ["docker-healthcheck"]
+# * timeout is 10s instead of 5s as longer has happened in practice
+HEALTHCHECK --interval=1s --start-period=45s --timeout=10s --retries=15 CMD ["docker-healthcheck"]
 
 ENTRYPOINT ["start-servicemanager"]


### PR DESCRIPTION
If a single invocation of health check exceeds the timeout, the
container is marked unhealthy. This doubles the value as recently
failures have happened due to timeout during bootstrap of
hypertrace/hypertrace/docker