### PR TITLE
Moves to Jitpack for service manager and cleans logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - gradle:
           args: dockerBuildImages
       - run:
-          name: Verify service manager
+          name: Verify pinot-servicemanager image
           working_directory: .circleci/pinot-servicemanager
           command: |
             docker-compose up -d
@@ -73,7 +73,10 @@ jobs:
                 unhealthy) exit 1;;
               esac
             done
-            exit 1
+      - run:
+          name: Time pinot-servicemanager bootstrap
+          working_directory: .circleci/pinot-servicemanager
+          command: docker-compose logs sut |grep since
       - save_populated_cache
   merge-publish:
     executor: gradle_docker

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -44,7 +44,7 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: dockerBuildImages
-      - name: Test Pinot Service Manager image
+      - name: Verify pinot-servicemanager image
         working-directory: ./.github/workflows/servicemanager
         # Below tests a docker-compose.yml service named 'sut' with a valid HEALTHCHECK instruction:
         run: |
@@ -57,3 +57,6 @@ jobs:
             esac
           done
           exit 1
+      - name: Time pinot-servicemanager bootstrap
+        working-directory: ./.github/workflows/servicemanager
+        run: docker-compose logs sut |grep since

--- a/pinot-servicemanager/Dockerfile
+++ b/pinot-servicemanager/Dockerfile
@@ -1,22 +1,16 @@
 # Choose libraries we need from Pinot's image.
-# TODO: 0.5.0 does not have parallel start (PR 5917): 21a372b2f58f9c6e27fe9710d6952ed519342061
-# This is why we are still on SNAPSHOT.
-FROM apachepinot/pinot:0.6.0-SNAPSHOT-07a6289a0-20200925-jdk11 as install
 
+# Using the same image as we use in CircleCI to avoid transfer costs
+FROM cimg/openjdk:14.0.2 AS install
+
+# Override to build an image from a fork. Ex. kotharironak
+ARG JITPACK_USER=apache
+# Override to use a different expression, such as 'master-SNAPSHOT'
+#   Note: 0.5.0 does not have parallel start (PR 5917): 21a372b2f58f9c6e27fe9710d6952ed519342061
+ARG JITPACK_TAG=23797914c6fea24e34f3ebfca9a73e0fff72c2b7
+
+USER root
 WORKDIR /install
-
-# TODO: use maven to do get deps so that we can avoid shaded jars
-RUN mkdir libs && cp \
-  /opt/pinot/lib/* \
-  /opt/pinot/plugins/pinot-input-format/pinot-confluent-avro/* \
-  /opt/pinot/plugins/pinot-stream-ingestion/pinot-kafka-2.0/* \
-  libs;
-
-# Pinot starts faster when classes are extracted
-# TODO: When we switch to Maven for pinot, use maven-dependency-plugin:unpack
-RUN mkdir classes && cd classes && \
-  (for JAR in ../libs/*; do jar -xf $JAR; done) && \
-  cd .. && rm -rf libs
 
 COPY schemas/* schemas/
 

--- a/pinot-servicemanager/docker-bin/install-schema
+++ b/pinot-servicemanager/docker-bin/install-schema
@@ -17,24 +17,24 @@ http_post() {
   echo
 }
 
+elapsed_seconds() {
+  # Uptime is always longer than the actual uptime in Docker.
+  # To get a more useful result, we subtract the time pid 1 launched.
+  uptime=$(awk '{print $1}' < /proc/uptime)
+  container_start=$(awk '{print $22}' < /proc/1/stat)
+  echo $(( ${uptime%.*} - $container_start / 100 ))
+}
+
 # Excessively long timeout to avoid having to create an ENV variable, decide its
 # name, etc. 180 seconds is 6 times as long as a modern laptop with contension.
 timeout=180
-echo "Will wait up to ${timeout} seconds for Pinot Server to come up before installing Schema"
-while [[ "$timeout" -gt 0 ]] && ! wget -qO- http://${IP}:8097/health > /dev/null 2>&1; do
+echo "Will wait up to ${timeout} seconds for Pinot Broker to register with controller"
+while [[ "$timeout" -gt 0 ]] && ! (wget -qO- http://${IP}:9000/brokers/tenants 2>&-| grep -q DefaultTenant); do
     sleep 1
     timeout=$(($timeout - 1))
 done
 
-# Wait for broker to registers
-timeout=30
-echo "Will wait up to ${timeout} seconds for Pinot Broker to registers with controller"
-while [[ "$timeout" -gt 0 ]] && ! (wget -qO- http://${IP}:9000/brokers/tenants | grep -q DefaultTenant); do
-    sleep 1
-    timeout=$(($timeout - 1))
-done
-
-echo "*** Starting schema installation"
+echo "*** Starting schema installation at $(elapsed_seconds)s since container launch"
 # Runs setup in parallel for each schema
 for path in $(ls schemas/*|cut -f 1 -d-|uniq); do
   (http_post "$IP" "9000" "/schemas" "$(cat $path-schemaFile.json | tr -d '\n')" && \
@@ -47,10 +47,4 @@ wait
 
 rmdir schemas
 
-# Uptime is always longer than the actual uptime in Docker.
-# To get a more useful result, we subtract the time pid 1 launched.
-uptime=$(awk '{print $1}' < /proc/uptime)
-container_start=$(awk '{print $22}' < /proc/1/stat)
-elapsed_seconds=$(( ${uptime%.*} - $container_start / 100 ))
-
-echo "*** Completed schema installation at ${elapsed_seconds}s since launch"
+echo "*** Completed schema installation at $(elapsed_seconds)s since container launch"

--- a/pinot-servicemanager/docker-bin/start-servicemanager
+++ b/pinot-servicemanager/docker-bin/start-servicemanager
@@ -34,9 +34,10 @@ test -d schemas && install-schema &
 
 echo Starting Pinot Service Manager
 # TODO: link to pinot issue why we need internal access
+# NOTE: '-classpath classes' because it is faster to start up with a flat classpath
 exec java \
   --add-opens java.base/jdk.internal.ref=ALL-UNNAMED \
-  -classpath 'classes:libs/*' \
+  -classpath classes \
   $JAVA_OPTS \
   -Dlog4j.configurationFile=etc/log4j2.properties \
   -Dapp.name=pinot-admin \

--- a/pinot-servicemanager/install.sh
+++ b/pinot-servicemanager/install.sh
@@ -17,6 +17,7 @@ done
 
 # TODO: try maven-dependency-plugin:unpack instead of wget
 #       https://maven.apache.org/plugins/maven-dependency-plugin/examples/unpacking-artifacts.html
+#       https://github.com/hypertrace/pinot/issues/16
 
 mkdir etc
 

--- a/pinot-servicemanager/install.sh
+++ b/pinot-servicemanager/install.sh
@@ -4,6 +4,20 @@
 # This also trims dependencies to only those used at runtime.
 set -eux
 
+# Choose the main distribution and the plugins we use
+for artifactId in pinot-distribution pinot-confluent-avro pinot-kafka-2.0
+do
+  # Download scripts and config for Kafka and ZooKeeper, but not for Connect
+  wget -qO temp.zip https://jitpack.io/com/github/${JITPACK_USER}/incubator-pinot/${artifactId}/${JITPACK_TAG}/${artifactId}-${JITPACK_TAG}-shaded.jar
+  # Pinot starts faster when classes are extracted
+  unzip -qo temp.zip -d classes
+  # remove license because sometimes a file and other times a directory
+  rm -rf temp.zip classes/META-INF/license
+done
+
+# TODO: try maven-dependency-plugin:unpack instead of wget
+#       https://maven.apache.org/plugins/maven-dependency-plugin/examples/unpacking-artifacts.html
+
 mkdir etc
 
 cat > etc/log4j2.properties <<-'EOF'


### PR DESCRIPTION
This makes logging more succinct and clear, especially when grepping for 'since'

```bash
pinot                   | 08:46:22,986 INFO  [main] command.StartServiceManagerCommand (StartServiceManagerCommand.java:285) - Starting a Pinot [SERVICE_MANAGER] at 0.007s since launch
pinot                   | 08:46:27,220 INFO  [main] command.StartServiceManagerCommand (StartServiceManagerCommand.java:287) - Started Pinot [SERVICE_MANAGER] instance [ServiceManager_20da8f16c3fb_7098] at 4.242s since launch
pinot                   | 08:46:27,246 INFO  [main] command.StartServiceManagerCommand (StartServiceManagerCommand.java:285) - Starting a Pinot [CONTROLLER] at 4.268s since launch
pinot                   | 08:46:32,430 INFO  [main] command.StartServiceManagerCommand (StartServiceManagerCommand.java:287) - Started Pinot [CONTROLLER] instance [Controller_20da8f16c3fb_9000] at 9.452s since launch
pinot                   | 08:46:32,432 INFO  [Start a Pinot [BROKER]] command.StartServiceManagerCommand (StartServiceManagerCommand.java:285) - Starting a Pinot [BROKER] at 9.453s since launch
pinot                   | 08:46:32,432 INFO  [Start a Pinot [SERVER]] command.StartServiceManagerCommand (StartServiceManagerCommand.java:285) - Starting a Pinot [SERVER] at 9.453s since launch
pinot                   | 08:46:35,755 INFO  [Start a Pinot [BROKER]] command.StartServiceManagerCommand (StartServiceManagerCommand.java:287) - Started Pinot [BROKER] instance [Broker_20da8f16c3fb_8099] at 12.777s since launch
pinot                   | 08:46:35,972 INFO  [Start a Pinot [SERVER]] command.StartServiceManagerCommand (StartServiceManagerCommand.java:287) - Started Pinot [SERVER] instance [Server_20da8f16c3fb_8098] at 12.993s since launch
pinot                   | *** Starting schema installation at 15s since container launch
pinot                   | *** Completed schema installation at 17s since container launch
```