### PR TITLE
chore: print all logs on the console

### DIFF
--- a/helm/templates/broker/log-configmap.yaml
+++ b/helm/templates/broker/log-configmap.yaml
@@ -20,7 +20,7 @@ data:
         </Console>
       </Appenders>
       <Loggers>
-        <Root level="info" additivity="false">
+        <Root level={{ .Values.broker.logging.level | quote }} additivity="false">
           <!-- Display most logs on the console -->
           <AppenderRef ref="console"/>
         </Root>

--- a/helm/templates/broker/log-configmap.yaml
+++ b/helm/templates/broker/log-configmap.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.broker.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pinot.broker.fullname" . }}-log-config
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.broker.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  pinot-broker-log4j2.xml: |-
+    <Configuration>
+      <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+          <PatternLayout>
+            <pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</pattern>
+          </PatternLayout>
+        </Console>
+      </Appenders>
+      <Loggers>
+        <Root level="info" additivity="false">
+          <!-- Display most logs on the console -->
+          <AppenderRef ref="console"/>
+        </Root>
+        <AsyncLogger name="org.reflections" level="error" additivity="false"/>
+      </Loggers>
+    </Configuration>
+{{- end }}

--- a/helm/templates/broker/statefulset.yml
+++ b/helm/templates/broker/statefulset.yml
@@ -57,6 +57,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /var/pinot/broker/config
+            - name: log-config
+              mountPath: /opt/pinot/conf/pinot-broker-log4j2.xml
+              subPath: "pinot-broker-log4j2.xml"
           livenessProbe:
             httpGet:
               path: /health
@@ -108,6 +111,9 @@ spec:
         - name: jmx-config
           configMap:
             name: {{ include "pinot.broker.fullname" . }}-jmx-config
+        - name: log-config
+          configMap:
+            name: {{ include "pinot.broker.fullname" . }}-log-config
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}

--- a/helm/templates/controller/log-configmap.yaml
+++ b/helm/templates/controller/log-configmap.yaml
@@ -21,7 +21,7 @@ data:
 
       </Appenders>
       <Loggers>
-        <Root level="info" additivity="false">
+        <Root level={{ .Values.controller.logging.level | quote }} additivity="false">
           <!-- Display most logs on the console -->
           <AppenderRef ref="console"/>
         </Root>

--- a/helm/templates/controller/log-configmap.yaml
+++ b/helm/templates/controller/log-configmap.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.controller.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pinot.controller.fullname" . }}-log-config
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.controller.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  pinot-controller-log4j2.xml: |-
+    <Configuration>
+      <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+          <PatternLayout>
+            <pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</pattern>
+          </PatternLayout>
+        </Console>
+
+      </Appenders>
+      <Loggers>
+        <Root level="info" additivity="false">
+          <!-- Display most logs on the console -->
+          <AppenderRef ref="console"/>
+        </Root>
+        <AsyncLogger name="org.reflections" level="error" additivity="false"/>
+      </Loggers>
+    </Configuration>
+{{- end }}

--- a/helm/templates/controller/statefulset.yaml
+++ b/helm/templates/controller/statefulset.yaml
@@ -77,6 +77,9 @@ spec:
               mountPath: /var/pinot/controller/config
             - name: pinot-controller-storage
               mountPath: "{{ .Values.controller.persistence.mountPath }}"
+            - name: log-config
+              mountPath: /opt/pinot/conf/pinot-controller-log4j2.xml
+              subPath: "pinot-controller-log4j2.xml"
             {{- if eq .Values.cluster.storage.scheme "gs" }}
             - name: gcs-iam-secret
               mountPath: "/account"
@@ -132,6 +135,9 @@ spec:
         - name: jmx-config
           configMap:
             name: {{ include "pinot.controller.fullname" . }}-jmx-config
+        - name: log-config
+          configMap:
+            name: {{ include "pinot.controller.fullname" . }}-log-config
         {{- if not .Values.controller.persistence.enabled }}
         - name: pinot-controller-storage
           emptyDir: {}

--- a/helm/templates/server/log-configmap.yaml
+++ b/helm/templates/server/log-configmap.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.server.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pinot.server.fullname" . }}-log-config
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.server.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  pinot-server-log4j2.xml: |-
+    <Configuration>
+      <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+          <PatternLayout>
+            <pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</pattern>
+          </PatternLayout>
+        </Console>
+      </Appenders>
+      <Loggers>
+        <Root level="info" additivity="false">
+          <!-- Display most logs on the console -->
+          <AppenderRef ref="console"/>
+        </Root>
+        <AsyncLogger name="org.reflections" level="error" additivity="false"/>
+      </Loggers>
+    </Configuration>
+{{- end }}

--- a/helm/templates/server/log-configmap.yaml
+++ b/helm/templates/server/log-configmap.yaml
@@ -20,7 +20,7 @@ data:
         </Console>
       </Appenders>
       <Loggers>
-        <Root level="info" additivity="false">
+        <Root level={{ .Values.server.logging.level | quote }} additivity="false">
           <!-- Display most logs on the console -->
           <AppenderRef ref="console"/>
         </Root>

--- a/helm/templates/server/statefulset.yml
+++ b/helm/templates/server/statefulset.yml
@@ -61,6 +61,9 @@ spec:
               mountPath: /var/pinot/server/config
             - name: pinot-server-storage
               mountPath: "{{ .Values.server.persistence.mountPath }}"
+            - name: log-config
+              mountPath: /opt/pinot/conf/pinot-server-log4j2.xml
+              subPath: "pinot-server-log4j2.xml"
             {{- if eq .Values.cluster.storage.scheme "gs" }}
             - name: gcs-iam-secret
               mountPath: "/account"
@@ -114,6 +117,9 @@ spec:
         - name: jmx-config
           configMap:
             name: {{ include "pinot.server.fullname" . }}-jmx-config
+        - name: log-config
+          configMap:
+            name: {{ include "pinot.server.fullname" . }}-log-config
         {{- if not .Values.server.persistence.enabled }}
         - name: pinot-server-storage
           emptyDir: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -138,6 +138,9 @@ controller:
     enabled: false
     namespace: monitoring
 
+  logging:
+    level: info
+
 broker:
   name: broker
   enabled: true
@@ -235,6 +238,9 @@ broker:
         requests:
           cpu: "0.25"
           memory: "256Mi"
+
+  logging:
+    level: info
 
 server:
   name: server
@@ -347,6 +353,8 @@ server:
     parameters:
       type: pd-standard
 
+  logging:
+    level: info
 
 servicemanager:
   name: servicemanager


### PR DESCRIPTION
By default, only `warn` logs are printed on the console. Overriding log4j2.xml file for pinot broker, controller and server.