### PR TITLE
use tcp liveness probe for controller and server

### DIFF
--- a/helm/templates/controller/statefulset.yaml
+++ b/helm/templates/controller/statefulset.yaml
@@ -85,8 +85,7 @@ spec:
               mountPath: "/account"
             {{- end }}
           livenessProbe:
-            httpGet:
-              path: /pinot-controller/admin
+            tcpSocket:
               port: {{ .Values.controller.port }}
             initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}

--- a/helm/templates/server/statefulset.yml
+++ b/helm/templates/server/statefulset.yml
@@ -69,9 +69,8 @@ spec:
               mountPath: "/account"
             {{- end }}
           livenessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.server.ports.admin }}
+            tcpSocket:
+              port: {{ .Values.server.ports.netty }}
             initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}


### PR DESCRIPTION
pinot-servers takes a lot of time for loading segments during startup. Due to which, http based liveness probes fail and restart the pods. 