### PR TITLE
create DNS record for pinot servers before the pods are ready

### DIFF
--- a/helm/templates/server/service-headless.yaml
+++ b/helm/templates/server/service-headless.yaml
@@ -9,8 +9,11 @@ metadata:
     component: {{ .Values.server.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: request
       port: {{ .Values.server.ports.netty }}

--- a/helm/templates/server/statefulset.yml
+++ b/helm/templates/server/statefulset.yml
@@ -109,6 +109,7 @@ spec:
         {{- end }}
       restartPolicy: Always
       serviceAccountName: {{ include "pinot.server.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       volumes:
         - name: config
           configMap:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -93,7 +93,7 @@ controller:
     create: true
     name: ""
 
-  terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 60
 
   servicemonitor:
     enabled: false
@@ -312,7 +312,7 @@ server:
     create: true
     name: ""
 
-  terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 60
 
   servicemonitor:
     enabled: false


### PR DESCRIPTION
During pinot-server startup, the segments are marked online but brokers are not able to access them as the DNS record for the pod will not be created till the pod is in ready state. Hence, the queries fails during the startup period.
Now, the pod DNS record will be created even if the pod is not ready.