### PR TITLE
exposing env property for changing log level for servicemanager

### DIFF
--- a/pinot-servicemanager/docker-bin/start-servicemanager
+++ b/pinot-servicemanager/docker-bin/start-servicemanager
@@ -8,10 +8,12 @@ set -eu
 # Default variables so that the script doesn't bomb out on absence
 JAVA_OPTS=${JAVA_OPTS:-"-Xms256M -Xmx512M -XX:+ExitOnOutOfMemoryError"}
 ZK_ADDRESS=${ZK_ADDRESS:-zookeeper:2181}
+LOG_LEVEL=${LOG_LEVEL:-info}
 
 # Apply one-time deferred configuration that relies on ENV variables
 #
 sed -i "s/\(controller.zk.str\)=.*/\1=${ZK_ADDRESS}/g" etc/pinot-controller.conf
+sed -i "s/\(rootLogger.level\)=.*/\1=${LOG_LEVEL}/g" etc/log4j2.properties
 # TODO: Revert this when relative paths are allowed
 #         https://github.com/apache/incubator-pinot/issues/5975
 sed -i "s~\./~${PWD}/~g" etc/*.conf

--- a/pinot-servicemanager/install.sh
+++ b/pinot-servicemanager/install.sh
@@ -35,7 +35,7 @@ appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
-rootLogger.level=error
+rootLogger.level=info
 rootLogger.appenderRefs=stdout
 rootLogger.appenderRef.stdout.ref=STDOUT
 # Hush reflections similarly to https://github.com/apache/incubator-pinot/pull/5001

--- a/pinot-servicemanager/install.sh
+++ b/pinot-servicemanager/install.sh
@@ -35,7 +35,7 @@ appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
-rootLogger.level=warn
+rootLogger.level=error
 rootLogger.appenderRefs=stdout
 rootLogger.appenderRef.stdout.ref=STDOUT
 # Hush reflections similarly to https://github.com/apache/incubator-pinot/pull/5001


### PR DESCRIPTION
This will help in an issue - https://github.com/hypertrace/pinot/issues/26 (see for more details)
This will help in overriding log level by
```
environment:
      - LOG_LEVEL=error
```
