### PR TITLE
feat: add udf for conditional and stringequals

### DIFF
--- a/pinot-udf/build.gradle.kts
+++ b/pinot-udf/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 dependencies {
-  implementation("org.hypertrace.core.attribute.service:attribute-projection-functions:0.4.1")
+  implementation("org.hypertrace.core.attribute.service:attribute-projection-functions:0.7.0")
   compileOnly("org.apache.pinot:pinot-common:0.5.0")
 }

--- a/pinot-udf/build.gradle.kts
+++ b/pinot-udf/build.gradle.kts
@@ -1,8 +1,16 @@
 plugins {
   `java-library`
+  jacoco
+  id("org.hypertrace.jacoco-report-plugin") version "0.1.0"
 }
 
 dependencies {
   implementation("org.hypertrace.core.attribute.service:attribute-projection-functions:0.7.0")
   compileOnly("org.apache.pinot:pinot-common:0.5.0")
+
+  testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+}
+
+tasks.test {
+  useJUnitPlatform()
 }

--- a/pinot-udf/src/main/java/org/apache/pinot/scalar/function/hypertrace/HypertraceScalarFunctions.java
+++ b/pinot-udf/src/main/java/org/apache/pinot/scalar/function/hypertrace/HypertraceScalarFunctions.java
@@ -3,7 +3,9 @@ package org.apache.pinot.scalar.function.hypertrace;
 import static java.util.Objects.isNull;
 
 import org.apache.pinot.common.function.annotations.ScalarFunction;
+import org.hypertrace.core.attribute.service.projection.functions.Conditional;
 import org.hypertrace.core.attribute.service.projection.functions.DefaultValue;
+import org.hypertrace.core.attribute.service.projection.functions.Equals;
 import org.hypertrace.core.attribute.service.projection.functions.Hash;
 
 public class HypertraceScalarFunctions {
@@ -11,6 +13,8 @@ public class HypertraceScalarFunctions {
   private static final String NULL_STRING = "null";
   public static final String HASH_FUNCTION_NAME = "hash";
   public static final String DEFAULT_STRING_FUNCTION_NAME = "defaultString";
+  public static final String CONDITIONAL_FUNCTION_NAME = "conditional";
+  public static final String STRING_EQUALS_FUNCTION_NAME = "stringEquals";
 
   @ScalarFunction(name = HASH_FUNCTION_NAME)
   public static String hash(String value) {
@@ -22,6 +26,17 @@ public class HypertraceScalarFunctions {
     return replaceNullWithNullString(
         DefaultValue.defaultString(
             replaceNullStringWithNull(value), replaceNullStringWithNull(defaultValue)));
+  }
+
+  @ScalarFunction(name = STRING_EQUALS_FUNCTION_NAME)
+  public static String stringEquals(String s1, String s2) {
+    return String.valueOf(Equals.stringEquals(s1, s2));
+  }
+
+  @ScalarFunction(name = CONDITIONAL_FUNCTION_NAME)
+  public static String conditional(String condition, String s1, String s2) {
+    Boolean conditionBooleanVal = Boolean.getBoolean(condition);
+    return replaceNullWithNullString(Conditional.getValue(conditionBooleanVal, s1, s2));
   }
 
   private static String replaceNullStringWithNull(String value) {

--- a/pinot-udf/src/main/java/org/apache/pinot/scalar/function/hypertrace/HypertraceScalarFunctions.java
+++ b/pinot-udf/src/main/java/org/apache/pinot/scalar/function/hypertrace/HypertraceScalarFunctions.java
@@ -35,7 +35,7 @@ public class HypertraceScalarFunctions {
 
   @ScalarFunction(name = CONDITIONAL_FUNCTION_NAME)
   public static String conditional(String condition, String s1, String s2) {
-    Boolean conditionBooleanVal = Boolean.getBoolean(condition);
+    Boolean conditionBooleanVal = NULL_STRING.equals(condition) ? null : Boolean.parseBoolean(condition);
     return replaceNullWithNullString(Conditional.getValue(conditionBooleanVal, s1, s2));
   }
 

--- a/pinot-udf/src/main/java/org/apache/pinot/scalar/function/hypertrace/HypertraceScalarFunctions.java
+++ b/pinot-udf/src/main/java/org/apache/pinot/scalar/function/hypertrace/HypertraceScalarFunctions.java
@@ -35,7 +35,10 @@ public class HypertraceScalarFunctions {
 
   @ScalarFunction(name = CONDITIONAL_FUNCTION_NAME)
   public static String conditional(String condition, String s1, String s2) {
-    Boolean conditionBooleanVal = NULL_STRING.equals(condition) ? null : Boolean.parseBoolean(condition);
+    // Pinot should never pass in a null condition but in case it does, make sure that it behaves
+    // the same as passing in "null" condition.
+    Boolean conditionBooleanVal = NULL_STRING.equals(replaceNullWithNullString(condition)) ?
+        null : Boolean.parseBoolean(condition);
     return replaceNullWithNullString(Conditional.getValue(conditionBooleanVal, s1, s2));
   }
 

--- a/pinot-udf/src/test/java/org/apache/pinot/scalar/function/hypertrace/HypertraceScalarFunctionsTest.java
+++ b/pinot-udf/src/test/java/org/apache/pinot/scalar/function/hypertrace/HypertraceScalarFunctionsTest.java
@@ -33,7 +33,7 @@ public class HypertraceScalarFunctionsTest {
     assertEquals("foo", HypertraceScalarFunctions.conditional("TRuE", "foo", "bar"));
     assertEquals("bar", HypertraceScalarFunctions.conditional("FALSE", "foo", "bar"));
     assertEquals("null", HypertraceScalarFunctions.conditional("null", "foo", "bar"));
-    assertEquals("bar", HypertraceScalarFunctions.conditional(null, "foo", "bar"));
+    assertEquals("null", HypertraceScalarFunctions.conditional(null, "foo", "bar"));
     assertEquals("null", HypertraceScalarFunctions.conditional("false", "foo", null));
   }
 }

--- a/pinot-udf/src/test/java/org/apache/pinot/scalar/function/hypertrace/HypertraceScalarFunctionsTest.java
+++ b/pinot-udf/src/test/java/org/apache/pinot/scalar/function/hypertrace/HypertraceScalarFunctionsTest.java
@@ -1,0 +1,39 @@
+package org.apache.pinot.scalar.function.hypertrace;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hypertrace.core.attribute.service.projection.functions.Hash;
+import org.junit.jupiter.api.Test;
+
+public class HypertraceScalarFunctionsTest {
+  @Test
+  public void testHash() {
+    assertEquals(Hash.hash("foo"), HypertraceScalarFunctions.hash("foo"));
+    assertEquals("null", HypertraceScalarFunctions.hash("null"));
+    assertEquals("null", HypertraceScalarFunctions.hash(null));
+  }
+
+  @Test
+  public void testDefaultString() {
+    assertEquals("foo", HypertraceScalarFunctions.defaultString("foo", "bar"));
+    assertEquals("bar", HypertraceScalarFunctions.defaultString("", "bar"));
+    assertEquals("bar", HypertraceScalarFunctions.defaultString("null", "bar"));
+    assertEquals("null", HypertraceScalarFunctions.defaultString("", "null"));
+  }
+
+  @Test
+  public void testStringEquals() {
+    assertEquals("true", HypertraceScalarFunctions.stringEquals("foo", "foo"));
+    assertEquals("false", HypertraceScalarFunctions.stringEquals("foo", ""));
+  }
+
+  @Test
+  public void testConditional() {
+    assertEquals("foo", HypertraceScalarFunctions.conditional("true", "foo", "bar"));
+    assertEquals("foo", HypertraceScalarFunctions.conditional("TRuE", "foo", "bar"));
+    assertEquals("bar", HypertraceScalarFunctions.conditional("FALSE", "foo", "bar"));
+    assertEquals("null", HypertraceScalarFunctions.conditional("null", "foo", "bar"));
+    assertEquals("bar", HypertraceScalarFunctions.conditional(null, "foo", "bar"));
+    assertEquals("null", HypertraceScalarFunctions.conditional("false", "foo", null));
+  }
+}


### PR DESCRIPTION
## Description
Adding scalar function(udf) for conditional and string equals. A follow up to https://github.com/hypertrace/attribute-service/pull/31

### Testing
Added unit tests for the existing and new UDFs

### Checklist:
- [ ✅ ] My changes generate no new warnings
- [ ✅ ] I have added tests that prove my fix is effective or that my feature works
- [✅  ] Any dependent changes have been merged and published in downstream modules
