### PR TITLE
feat: adding backend_operation column in pinot_servicemanager schema

### DIFF
--- a/pinot-servicemanager/schemas/backendEntityView-schemaFile.json
+++ b/pinot-servicemanager/schemas/backendEntityView-schemaFile.json
@@ -114,6 +114,10 @@
       "name": "space_ids",
       "dataType": "STRING",
       "singleValueField": false
+    },
+    {
+      "name": "backend_operation",
+      "dataType": "STRING"
     }
   ],
   "timeFieldSpec": {


### PR DESCRIPTION
## Description
Adding backend_operation column in pinot_servicemanager column as we are working on adding `Operation` column in Backend Trace (call) view. 


### Testing
NA

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
