### PR TITLE
chore: adds backend_destination column in servicemanager schema

### DIFF
--- a/pinot-servicemanager/schemas/backendEntityView-schemaFile.json
+++ b/pinot-servicemanager/schemas/backendEntityView-schemaFile.json
@@ -118,6 +118,10 @@
     {
       "name": "backend_operation",
       "dataType": "STRING"
+    }, 
+    {
+      "name": "backend_destination",
+      "dataType": "STRING"
     }
   ],
   "timeFieldSpec": {


### PR DESCRIPTION
## Description
Adding backend_destination column in pinot_servicemanager schema as we are working on adding Destination column in Backend Trace (call) view.


### Testing
NA

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

