### PR TITLE
chore: adds api_trace_error_count column

### DIFF
--- a/pinot-servicemanager/schemas/spanEventView-schemaFile.json
+++ b/pinot-servicemanager/schemas/spanEventView-schemaFile.json
@@ -133,6 +133,11 @@
       "defaultNullValue": 0
     },
     {
+      "name": "api_trace_error_count",
+      "dataType": "INT",
+      "defaultNullValue": 0
+    },
+    {
       "name": "api_callee_name_count__KEYS",
       "dataType": "STRING",
       "singleValueField": false,

--- a/pinot-servicemanager/schemas/spanEventView-schemaFile.json
+++ b/pinot-servicemanager/schemas/spanEventView-schemaFile.json
@@ -133,7 +133,7 @@
       "defaultNullValue": 0
     },
     {
-      "name": "api_trace_error_count",
+      "name": "api_trace_error_span_count",
       "dataType": "INT",
       "defaultNullValue": 0
     },


### PR DESCRIPTION
## Description
- Adds api_trace_error_count column as per changes here: https://github.com/hypertrace/hypertrace-ingester/pull/172


### Testing
NA

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

