### PR TITLE
Minion config fix to work with deepstores

### DIFF
--- a/helm/templates/minion/configmap.yaml
+++ b/helm/templates/minion/configmap.yaml
@@ -12,4 +12,19 @@ metadata:
 data:
   pinot-minion.conf: |-
     pinot.minion.port={{ .Values.minion.port }}
+    {{- if eq .Values.cluster.storage.scheme "gs" }}
+    instance.enable.split.commit=true
+    storage.factory.class.gs=org.apache.pinot.plugin.filesystem.GcsPinotFS
+    storage.factory.gs.projectId={{ .Values.cluster.storage.gs.projectId }}
+    storage.factory.gs.gcpKey={{ .Values.cluster.storage.gs.gcpKey }}
+    segment.fetcher.protocols=file,http,gs
+    segment.fetcher.gs.class=org.apache.pinot.common.utils.fetcher.PinotFSSegmentFetcher
+    {{- end }}
+    {{- if eq .Values.cluster.storage.scheme "s3" }}
+    storage.factory.class.s3=org.apache.pinot.plugin.filesystem.S3PinotFS
+    storage.factory.s3.region={{ .Values.cluster.storage.s3.region }}
+    segment.fetcher.protocols=file,http,s3
+    segment.fetcher.s3.class=org.apache.pinot.common.utils.fetcher.PinotFSSegmentFetcher
+    storage.factory.s3.disableAcl=false
+    {{- end }}
 {{- end }}

--- a/helm/templates/minion/statefulset.yml
+++ b/helm/templates/minion/statefulset.yml
@@ -60,6 +60,10 @@ spec:
             - name: log-config
               mountPath: /opt/pinot/conf/pinot-minion-log4j2.xml
               subPath: "pinot-minion-log4j2.xml"
+            {{- if eq .Values.cluster.storage.scheme "gs" }}
+            - name: gcs-iam-secret
+              mountPath: "/account"
+            {{- end }}
 #          livenessProbe:
 #            httpGet:
 #              path: /health
@@ -114,6 +118,11 @@ spec:
         - name: log-config
           configMap:
             name: {{ include "pinot.minion.fullname" . }}-log-config
+        {{- if eq .Values.cluster.storage.scheme "gs" }}
+        - name: gcs-iam-secret
+          secret:
+            secretName: {{ .Values.cluster.storage.gs.secretName }}
+        {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}


### PR DESCRIPTION
## Description
Minions should be able to download and upload segments from/to gcs/s3 deepstores.


### Testing
Deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
NA