### PR TITLE
Mount a separate volume on minion pods

### DIFF
--- a/helm/templates/minion/configmap.yaml
+++ b/helm/templates/minion/configmap.yaml
@@ -13,6 +13,9 @@ data:
   pinot-minion.conf: |-
     pinot.minion.port={{ .Values.minion.port }}
     pinot.set.instance.id.to.hostname=true
+    {{- if .Values.minion.persistence.enabled }}
+    dataDir={{ .Values.minion.persistence.mountPath }}
+    {{- end }}
     {{- if eq .Values.cluster.storage.scheme "gs" }}
     instance.enable.split.commit=true
     storage.factory.class.gs=org.apache.pinot.plugin.filesystem.GcsPinotFS

--- a/helm/templates/minion/statefulset.yml
+++ b/helm/templates/minion/statefulset.yml
@@ -64,6 +64,10 @@ spec:
             - name: gcs-iam-secret
               mountPath: "/account"
             {{- end }}
+            {{- if .Values.minion.persistence.enabled }}
+            - name: pinot-minion-storage
+              mountPath: "{{ .Values.minion.persistence.mountPath }}"
+            {{- end }}
 #          livenessProbe:
 #            httpGet:
 #              path: /health
@@ -143,4 +147,22 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if .Values.minion.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: pinot-minion-storage
+      spec:
+        accessModes:
+          - {{ .Values.minion.persistence.accessMode | quote }}
+        {{- if .Values.minion.persistence.storageClass }}
+        {{- if (eq "-" .Values.minion.persistence.storageClass) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: {{ .Values.minion.persistence.storageClass }}
+        {{- end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.minion.persistence.size | quote}}
+  {{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -260,6 +260,13 @@ minion:
 
   jvmOpts: "-Xms128M -Xmx320M"
 
+  persistence:
+    enabled: false
+    accessMode: ReadWriteOnce
+    size: 2Gi
+    mountPath: /var/pinot/minion/data
+    storageClass: "standard"
+
   log4j2ConfFile: /opt/pinot/conf/pinot-minion-log4j2.xml
   pluginsDir: /opt/pinot/plugins
 


### PR DESCRIPTION
Pinot minion were using `/tmp` folder for RealtimeToOfflineSegmentsTask tasks.