### PR TITLE
additional pinot server pods

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -225,3 +225,29 @@ Docker image to use for controller, broker, minion and server
     {{- printf "%s:%s" .Values.image.repository .Chart.Version }}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified pinot server2 name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "pinot.server2.fullname" -}}
+{{- printf "%s-%s" (include "pinot.fullname" .) .Values.server2.name }}
+{{- end -}}
+
+{{/*
+The name of the pinot server2 headless service.
+*/}}
+{{- define "pinot.serve2r.headless" -}}
+{{- printf "%s-headless" (include "pinot.server2.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "pinot.server2.serviceAccountName" -}}
+{{- if .Values.server2.serviceAccount.create -}}
+{{ default (include "pinot.server2.fullname" .) .Values.server2.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.server2.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/helm/templates/controller/configmap.yaml
+++ b/helm/templates/controller/configmap.yaml
@@ -17,6 +17,7 @@ data:
     controller.vip.host={{ include "pinot.controller.fullname" . }}
     controller.vip.port={{ .Values.controller.service.port }}
     {{- end }}
+    controller.retention.frequencyInSeconds={{ .Values.controller.retention.frequencyInSeconds }}
     controller.task.scheduler.enabled={{ .Values.controller.taskScheduler.enabled }}
     controller.task.frequencyInSeconds={{ .Values.controller.taskScheduler.frequencyInSeconds }}
     controller.zk.str={{ include "zookeeper.path" . }}

--- a/helm/templates/server/configmap.yaml
+++ b/helm/templates/server/configmap.yaml
@@ -28,6 +28,9 @@ data:
     pinot.query.scheduler.query_runner_threads={{ int .Values.server.pqrThreadPoolSize }}
     {{- end }}
     {{- end }}
+    {{- if .Values.server.mountTmpFS }}
+    pinot.server.consumerDir=/var/tmpfs
+    {{- end }}
     {{- if eq .Values.cluster.storage.scheme "gs" }}
     {{- if .Values.cluster.splitCommitEnabled }}
     pinot.server.instance.enable.split.commit=true

--- a/helm/templates/server/configmap.yaml
+++ b/helm/templates/server/configmap.yaml
@@ -29,7 +29,7 @@ data:
     {{- end }}
     {{- end }}
     {{- if .Values.server.mountTmpFS }}
-    pinot.server.consumerDir=/var/tmpfs
+    pinot.server.instance.consumerDir=/var/tmpfs
     {{- end }}
     {{- if eq .Values.cluster.storage.scheme "gs" }}
     {{- if .Values.cluster.splitCommitEnabled }}

--- a/helm/templates/server/tags.yaml
+++ b/helm/templates/server/tags.yaml
@@ -1,0 +1,56 @@
+{{- if and .Values.server.enabled .Values.server.tags }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "pinot.server.fullname" . }}-tags
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.server.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook-weight: "100"
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  activeDeadlineSeconds: 600
+  backoffLimit: 100
+  ttlSecondsAfterFinished: 900
+  template:
+    metadata:
+      name: {{ include "pinot.server.fullname" . }}-tags
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "pinot.server.serviceAccountName" . }}
+      containers:
+        - name: {{ include "pinot.server.fullname" . }}-tags
+          image: curlimages/curl:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              finish() {
+                code=$?
+                curl -s -XPOST http://127.0.0.1:15020/quitquitquit
+                exit $code
+              }
+              trap finish EXIT
+              until curl -s --head localhost:15000; do echo "$(date) waiting for sidecar"; sleep 3; done
+              until [ "$(curl -s --head --connect-timeout 3 -o /dev/null -w '%{http_code}\n' 'http://{{ include "pinot.controller.fullname" . }}-svc:{{ int .Values.controller.service.port }}/')" == "200" ]; do
+                echo "$(date) waiting for {{ include "pinot.controller.fullname" . }} service"
+                sleep 3
+              done
+              sleep 5
+
+              i=0
+              while [ $i -lt {{ int .Values.server.replicaCount }} ]; do
+                HTTP_CODE=$(curl -s -o /tmp/out -w '%{http_code}\n' -X PUT -H 'Content-Type: application/json' -H 'Accept: application/json' "http://{{ include "pinot.controller.fullname" . }}-svc:{{ int .Values.controller.service.port }}/instances/Server_{{ include "pinot.server.fullname" . }}-${i}.{{ include "pinot.server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local_{{ int .Values.server.ports.netty }}/updateTags?tags={{ join "," .Values.server.tags }}")
+                cat /tmp/out; rm /tmp/out; echo
+                echo $HTTP_CODE
+                if [ $HTTP_CODE -lt 200 -o $HTTP_CODE -gt 299 ]; then
+                  exit 1
+                fi
+                i=$(expr $i + 1)
+              done
+{{- end }}

--- a/helm/templates/server2/configmap.yaml
+++ b/helm/templates/server2/configmap.yaml
@@ -28,7 +28,7 @@ data:
     pinot.query.scheduler.query_runner_threads={{ int .Values.server2.pqrThreadPoolSize }}
     {{- end }}
     {{- end }}
-    {{- if .Values.server.mountTmpFS }}
+    {{- if .Values.server2.mountTmpFS }}
     pinot.server.consumerDir=/var/tmpfs
     {{- end }}
     {{- if eq .Values.cluster.storage.scheme "gs" }}

--- a/helm/templates/server2/configmap.yaml
+++ b/helm/templates/server2/configmap.yaml
@@ -28,6 +28,9 @@ data:
     pinot.query.scheduler.query_runner_threads={{ int .Values.server2.pqrThreadPoolSize }}
     {{- end }}
     {{- end }}
+    {{- if .Values.server.mountTmpFS }}
+    pinot.server.consumerDir=/var/tmpfs
+    {{- end }}
     {{- if eq .Values.cluster.storage.scheme "gs" }}
     {{- if .Values.cluster.splitCommitEnabled }}
     pinot.server.instance.enable.split.commit=true

--- a/helm/templates/server2/configmap.yaml
+++ b/helm/templates/server2/configmap.yaml
@@ -1,31 +1,31 @@
-{{- if .Values.server.enabled }}
+{{- if .Values.server2.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "pinot.server.fullname" . }}-config
+  name: {{ include "pinot.server2.fullname" . }}-config
   labels:
     app: {{ include "pinot.name" . }}
     chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.server.name }}
+    component: {{ .Values.server2.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
   pinot-server.conf: |-
-    pinot.server.netty.port={{ .Values.server.ports.netty }}
-    pinot.server.adminapi.port={{ .Values.server.ports.admin }}
-    pinot.server.instance.dataDir={{ .Values.server.dataDir }}
-    pinot.server.instance.segmentTarDir={{ .Values.server.segmentTarDir }}
+    pinot.server.netty.port={{ .Values.server2.ports.netty }}
+    pinot.server.adminapi.port={{ .Values.server2.ports.admin }}
+    pinot.server.instance.dataDir={{ .Values.server2.dataDir }}
+    pinot.server.instance.segmentTarDir={{ .Values.server2.segmentTarDir }}
     pinot.set.instance.id.to.hostname=true
     pinot.server.instance.realtime.alloc.offheap=true
     pinot.server.query.executor.timeout=60000
-    {{- if hasKey .Values.server "pqwThreadPoolSize" }}
-    {{- if .Values.server.pqwThreadPoolSize }}
-    pinot.query.scheduler.query_worker_threads={{ int .Values.server.pqwThreadPoolSize }}
+    {{- if hasKey .Values.server2 "pqwThreadPoolSize" }}
+    {{- if .Values.server2.pqwThreadPoolSize }}
+    pinot.query.scheduler.query_worker_threads={{ int .Values.server2.pqwThreadPoolSize }}
     {{- end }}
     {{- end }}
-    {{- if hasKey .Values.server "pqrThreadPoolSize" }}
-    {{- if .Values.server.pqrThreadPoolSize }}
-    pinot.query.scheduler.query_runner_threads={{ int .Values.server.pqrThreadPoolSize }}
+    {{- if hasKey .Values.server2 "pqrThreadPoolSize" }}
+    {{- if .Values.server2.pqrThreadPoolSize }}
+    pinot.query.scheduler.query_runner_threads={{ int .Values.server2.pqrThreadPoolSize }}
     {{- end }}
     {{- end }}
     {{- if eq .Values.cluster.storage.scheme "gs" }}

--- a/helm/templates/server2/jmx-configmap.yaml
+++ b/helm/templates/server2/jmx-configmap.yaml
@@ -1,0 +1,199 @@
+{{- if .Values.server2.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pinot.server2.fullname" . }}-jmx-config
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.server2.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  prometheus-pinot-server.yml: |-
+    jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:{{ .Values.server2.jmx.port }}/jmxrmi
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    ssl: false
+    rules:
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.documentCount.(\\w+)_(\\w+)\"><>(\\w+)"
+        name: "pinot_server_documentCount_$3"
+        labels:
+          table: "$1"
+          tableType: "$2"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.segmentCount.(\\w+)_(\\w+)\"><>(\\w+)"
+        name: "pinot_server_segmentCount_$3"
+        labels:
+          table: "$1"
+          tableType: "$2"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+)\\.(\\w+)\"><>(\\w+)"
+        name: "pinot_server_$3_$4"
+        labels:
+          table: "$1"
+          tableType: "$2"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+)\\-(.+)\\-(\\w+).realtimeRowsConsumed\"><>(\\w+)"
+        name: "pinot_server_realtimeRowsConsumed_$5"
+        labels:
+          table: "$1"
+          tableType: "$2"
+          topic: "$3"
+          partition: "$4"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.helix.connected\"><>(\\w+)"
+        name: "pinot_server_helix_connected_$1"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.helixZookeeperReconnects\"><>(\\w+)"
+        name: "pinot_server_helix_zookeeperReconnects_$1"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.highestKafkaOffsetConsumed.(\\w+)_(\\w+)\\-(.+)\\-(\\w+)\"><>(\\w+)"
+        name: "pinot_server_highestKafkaOffsetConsumed_$5"
+        labels:
+          table: "$1"
+          tableType: "$2"
+          topic: "$3"
+          partition: "$4"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.highestStreamOffsetConsumed.(\\w+)_(\\w+)\\-(.+)\\-(\\w+)\"><>(\\w+)"
+        name: "pinot_server_highestStreamOffsetConsumed_$5"
+        labels:
+          table: "$1"
+          tableType: "$2"
+          topic: "$3"
+          partition: "$4"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.lastRealtimeSegment(\\w+)Seconds.(\\w+)_(\\w+)\\-(.+)\\-(\\w+)\"><>(\\w+)"
+        name: "pinot_server_lastRealtimeSegment$1Seconds_$6"
+        labels:
+          table: "$2"
+          tableType: "$3"
+          topic: "$4"
+          partition: "$5"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcControllerResponse(\\w+)\"><>(\\w+)"
+        name: "pinot_server_llcControllerResponse_$1_$2"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcPartitionConsuming.(\\w+)_(\\w+)\\-(.+)\\-(\\w+)\"><>(\\w+)"
+        name: "pinot_server_llcPartitionConsuming_$5"
+        labels:
+          table: "$1"
+          tableType: "$2"
+          topic: "$3"
+          partition: "$4"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcSimultaneousSegmentBuilds\"><>(\\w+)"
+        name: "pinot_server_llcSimultaneousSegmentBuilds_$1"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.memory.(\\w+)\"><>(\\w+)"
+        name: "pinot_server_memory_$1_$2"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.queries\"><>(\\w+)"
+        name: "pinot_server_queries_$1"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeConsumptionExceptions\"><>(\\w+)"
+        name: "pinot_server_realtime_consumptionExceptions_$1"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffheapMemoryUsed.(\\w+)\"><>(\\w+)"
+        name: "pinot_server_realtime_offheapMemoryUsed_$2"
+        labels:
+          table: "$1"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffsetCommits\"><>(\\w+)"
+        name: "pinot_server_realtime_offsetCommits_$1"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeRowsConsumed\"><>(\\w+)"
+        name: "pinot_server_realtime_rowsConsumed_$1"
+      - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)Exceptions\"><>(\\w+)"
+        name: "pinot_server_realtime_exceptions_$1_$2"
+      - pattern: "\"org.apache.pinot.transport.netty.NettyTCPServer_(\\w+)_\"<type=\"\", name=\"(\\w+)\"><>(\\w+)"
+        name: "pinot_server_netty_tcp_$2_$3"
+        labels:
+          id: "$1"
+      - pattern: "java.lang<name=CodeHeap 'non-nmethods', type=MemoryPool><>(\\w+)"
+        name: "java_lang_codeheap_non_nmethods_$1"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=CodeHeap 'non-nmethods', type=MemoryPool><(\\w+)>(\\w+)"
+        name: "java_lang_codeheap_non_nmethods_$1_$2"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=CodeHeap 'non-profiled nmethods', type=MemoryPool><>(\\w+)"
+        name: "java_lang_codeheap_non_profiled_nmethods_$1"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=CodeHeap 'non-profiled nmethods', type=MemoryPool><(\\w+)>(\\w+)"
+        name: "java_lang_codeheap_non_profiled_nmethods_$1_$2"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=CodeHeap 'profiled nmethods', type=MemoryPool><>(\\w+)"
+        name: "java_lang_codeheap_profiled_nmethods_$1"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=CodeHeap 'profiled nmethods', type=MemoryPool><(\\w+)>(\\w+)"
+        name: "java_lang_codeheap_profiled_nmethods_$1_$2"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=Compressed Class Space, type=MemoryPool><>(\\w+)"
+        name: "java_lang_compressed_class_space_$1"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=Compressed Class Space, type=MemoryPool><(\\w+)>(\\w+)"
+        name: "java_lang_compressed_class_space_$1_$2"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=G1 Eden Space, type=MemoryPool><>(\\w+)"
+        name: "java_lang_g1_eden_space_$1"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=G1 Eden Space, type=MemoryPool><(\\w+)>(\\w+)"
+        name: "java_lang_g1_eden_space_$1_$2"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=G1 Old Gen, type=MemoryPool><>(\\w+)"
+        name: "java_lang_g1_old_gen_$1"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=G1 Old Gen, type=MemoryPool><(\\w+)>(\\w+)"
+        name: "java_lang_g1_old_gen_$1_$2"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=G1 Survivor Space, type=MemoryPool><>(\\w+)"
+        name: "java_lang_g1_survivor_space_$1"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=G1 Survivor Space, type=MemoryPool><(\\w+)>(\\w+)"
+        name: "java_lang_g1_survivor_space_$1_$2"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=Metaspace, type=MemoryPool><>(\\w+)"
+        name: "java_lang_metaspace_$1"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=Metaspace, type=MemoryPool><(\\w+)>(\\w+)"
+        name: "java_lang_metaspace_$1_$2"
+        labels:
+          type: "MemoryPool"
+      - pattern: "java.lang<name=G1 Old Generation, type=GarbageCollector><>(\\w+)"
+        name: "java_lang_g1_old_generation_$1"
+        labels:
+          type: "GarbageCollector"
+      - pattern: "java.lang<name=G1 Young Generation, type=GarbageCollector, key=CodeHeap 'profiled nmethods'><LastGcInfo, memoryUsageAfterGc>(\\w+)"
+        name: "java_lang_g1_young_generation_lastgcinfo_memoryusageaftergc_$1"
+        labels:
+          type: "GarbageCollector"
+          key: "CodeHeap 'profiled nmethods'"
+      - pattern: "java.lang<name=G1 Young Generation, type=GarbageCollector, key=CodeHeap 'profiled nmethods'><LastGcInfo, memoryUsageBeforeGc>(\\w+)"
+        name: "java_lang_g1_young_generation_lastgcinfo_memoryusagebeforegc_$1"
+        labels:
+          type: "GarbageCollector"
+          key: "CodeHeap 'profiled nmethods'"
+      - pattern: "java.lang<name=G1 Young Generation, type=GarbageCollector><>(\\w+)"
+        name: "java_lang_g1_young_generation_$1"
+        labels:
+          type: "GarbageCollector"
+      - pattern: "java.lang<name=G1 Young Generation, type=GarbageCollector><(\\w+)>(\\w+)"
+        name: "java_lang_g1_young_generation_$1_$2"
+        labels:
+          type: "GarbageCollector"
+      - pattern: "java.lang<type=ClassLoading><>(\\w+)"
+        name: "java_lang_classloading_$1"
+      - pattern: "java.lang<type=Memory><(\\w+)>(\\w+)"
+        name: "java_lang_memory_$1_$2"
+      - pattern: "java.lang<type=OperatingSystem><>(\\w+)"
+        name: "java_lang_operatingsystem_$1"
+      - pattern: "java.lang<type=Threading><>(\\w+)"
+        name: "java_lang_threading_$1"
+      - pattern: "java.nio<name=direct, type=BufferPool><>(\\w+)"
+        name: "java_nio_direct_$1"
+        labels:
+          type: "BufferPool"
+      - pattern: "java.nio<name=mapped, type=BufferPool><>(\\w+)"
+        name: "java_nio_mapped_$1"
+        labels:
+          type: "BufferPool"
+{{- end }}

--- a/helm/templates/server2/log-configmap.yaml
+++ b/helm/templates/server2/log-configmap.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.server2.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pinot.server2.fullname" . }}-log-config
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.server2.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  pinot-server-log4j2.xml: |-
+    <Configuration>
+      <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+          <PatternLayout>
+            <pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</pattern>
+          </PatternLayout>
+        </Console>
+      </Appenders>
+      <Loggers>
+        <Root level={{ .Values.server2.logging.level | quote }} additivity="false">
+          <!-- Display most logs on the console -->
+          <AppenderRef ref="console"/>
+        </Root>
+        <AsyncLogger name="org.reflections" level="error" additivity="false"/>
+      </Loggers>
+    </Configuration>
+{{- end }}

--- a/helm/templates/server2/poddisruptionbudget.yaml
+++ b/helm/templates/server2/poddisruptionbudget.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.server2.enabled .Values.server2.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pinot.server2.fullname" . }}
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.server2.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if .Values.server2.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.server2.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.server2.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.server2.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      app: {{ include "pinot.name" . }}
+      release: {{ .Release.Name }}
+      component: {{ .Values.server2.name }}
+{{- end }}

--- a/helm/templates/server2/service-headless.yaml
+++ b/helm/templates/server2/service-headless.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.server2.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pinot.server2.fullname" . }}
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.server2.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: request
+      port: {{ .Values.server2.ports.netty }}
+  selector:
+    app: {{ include "pinot.name" . }}
+    release: {{ .Release.Name }}
+    component: {{ .Values.server2.name }}
+{{- end }}

--- a/helm/templates/server2/service.yaml
+++ b/helm/templates/server2/service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.server2.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pinot.server2.fullname" . }}-svc
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.server2.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: request
+      port: {{ .Values.server2.ports.netty }}
+    {{- if .Values.server2.prometheus.jmx.enabled }}
+    - name: prometheus-jmx
+      port: {{ .Values.server2.prometheus.jmx.port }}
+    {{- end }}
+  selector:
+    app: {{ include "pinot.name" . }}
+    release: {{ .Release.Name }}
+    component: {{ .Values.server2.name }}
+{{- end }}

--- a/helm/templates/server2/serviceaccount.yaml
+++ b/helm/templates/server2/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.server2.enabled .Values.server2.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pinot.server2.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.server2.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.server2.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/helm/templates/server2/servicemonitor.yaml
+++ b/helm/templates/server2/servicemonitor.yaml
@@ -1,0 +1,41 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.server2.enabled ) ( .Values.server2.prometheus.jmx.enabled ) ( .Values.server2.servicemonitor.enabled ) }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "pinot.server2.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.server2.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    monitoring: shared
+spec:
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - {{ include "pinot.name" . }}
+      - key: release
+        operator: In
+        values:
+          - {{ .Release.Name }}
+      - key: component
+        operator: In
+        values:
+          - {{ .Values.server2.name }}
+  endpoints:
+    - port: prometheus-jmx
+      interval: {{ .Values.server2.servicemonitor.interval }}
+      {{- if .Values.server2.servicemonitor.secure }}
+      scheme: https
+      tlsConfig:
+        {{- toYaml .Values.server2.servicemonitor.tlsConfig | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/helm/templates/server2/statefulset.yml
+++ b/helm/templates/server2/statefulset.yml
@@ -1,12 +1,12 @@
-{{- if .Values.server.enabled }}
+{{- if .Values.server2.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "pinot.server.fullname" . }}
+  name: {{ include "pinot.server2.fullname" . }}
   labels:
     app: {{ include "pinot.name" . }}
     chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.server.name }}
+    component: {{ .Values.server2.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -14,22 +14,22 @@ spec:
     matchLabels:
       app: {{ include "pinot.name" . }}
       release: {{ .Release.Name }}
-      component: {{ .Values.server.name }}
-  serviceName: {{ include "pinot.server.fullname" . }}
-  replicas: {{ .Values.server.replicaCount }}
+      component: {{ .Values.server2.name }}
+  serviceName: {{ include "pinot.server2.fullname" . }}
+  replicas: {{ .Values.server2.replicaCount }}
   updateStrategy:
-    type: {{ .Values.server.updateStrategy.type }}
+    type: {{ .Values.server2.updateStrategy.type }}
   podManagementPolicy: Parallel
   template:
     metadata:
       labels:
         app: {{ include "pinot.name" . }}
         release: {{ .Release.Name }}
-        component: {{ .Values.server.name }}
-      {{- with .Values.server.podLabels }}
+        component: {{ .Values.server2.name }}
+      {{- with .Values.server2.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      annotations: {{ toYaml .Values.server.podAnnotations | nindent 8 }}
+      annotations: {{ toYaml .Values.server2.podAnnotations | nindent 8 }}
     spec:
       containers:
         - name: pinot-server
@@ -43,24 +43,24 @@ spec:
           ]
           env:
             - name: JAVA_OPTS
-              value: "{{ .Values.server.jvmOpts }} -Dlog4j2.configurationFile={{ .Values.server.log4j2ConfFile }} -Dplugins.dir={{ .Values.server.pluginsDir }}  {{ if .Values.server.jmx.enabled }}{{ .Values.server.jmx.opts }}{{ end }}"
+              value: "{{ .Values.server2.jvmOpts }} -Dlog4j2.configurationFile={{ .Values.server2.log4j2ConfFile }} -Dplugins.dir={{ .Values.server2.pluginsDir }}  {{ if .Values.server2.jmx.enabled }}{{ .Values.server2.jmx.opts }}{{ end }}"
           ports:
             - name: request
-              containerPort: {{ .Values.server.ports.netty }}
+              containerPort: {{ .Values.server2.ports.netty }}
               protocol: TCP
             - name: admin
-              containerPort: {{ .Values.server.ports.admin }}
+              containerPort: {{ .Values.server2.ports.admin }}
               protocol: TCP
-            {{- if .Values.server.jmx.enabled }}
+            {{- if .Values.server2.jmx.enabled }}
             - name: jmx
-              containerPort: {{ .Values.server.jmx.port }}
+              containerPort: {{ .Values.server2.jmx.port }}
               protocol: TCP
             {{- end }}
           volumeMounts:
             - name: config
               mountPath: /var/pinot/server/config
             - name: pinot-server-storage
-              mountPath: "{{ .Values.server.persistence.mountPath }}"
+              mountPath: "{{ .Values.server2.persistence.mountPath }}"
             - name: log-config
               mountPath: /opt/pinot/conf/pinot-server-log4j2.xml
               subPath: "pinot-server-log4j2.xml"
@@ -68,30 +68,30 @@ spec:
             - name: gcs-iam-secret
               mountPath: "/account"
             {{- end }}
-            {{- if .Values.server.mountTmpFS }}
+            {{- if .Values.server2.mountTmpFS }}
             - name: pinot-tmpfs
               mountPath: "/var/tmpfs"
             {{- end }}
           livenessProbe:
             tcpSocket:
-              port: {{ .Values.server.ports.netty }}
-            initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.server.livenessProbe.failureThreshold }}
+              port: {{ .Values.server2.ports.netty }}
+            initialDelaySeconds: {{ .Values.server2.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server2.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.server2.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.server2.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /health
-              port: {{ .Values.server.ports.admin }}
-            initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.server.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
-          resources: {{ toYaml .Values.server.resources | nindent 12 }}
-        {{- if .Values.server.prometheus.jmx.enabled }}
+              port: {{ .Values.server2.ports.admin }}
+            initialDelaySeconds: {{ .Values.server2.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server2.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.server2.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.server2.readinessProbe.failureThreshold }}
+          resources: {{ toYaml .Values.server2.resources | nindent 12 }}
+        {{- if .Values.server2.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter
-          image: "{{ .Values.server.prometheus.jmx.image.repository }}:{{ .Values.server.prometheus.jmx.image.tag }}"
-          imagePullPolicy: "{{ .Values.server.prometheus.jmx.image.pullPolicy }}"
+          image: "{{ .Values.server2.prometheus.jmx.image.repository }}:{{ .Values.server2.prometheus.jmx.image.tag }}"
+          imagePullPolicy: "{{ .Values.server2.prometheus.jmx.image.pullPolicy }}"
           command:
             - java
             - -XX:+UnlockExperimentalVMOptions
@@ -100,80 +100,80 @@ spec:
             - -XshowSettings:vm
             - -jar
             - jmx_prometheus_httpserver.jar
-            - {{ .Values.server.prometheus.jmx.port | quote }}
+            - {{ .Values.server2.prometheus.jmx.port | quote }}
             - /etc/jmx-config/prometheus-pinot-server.yml
           ports:
             - name: prometheus-jmx
-              containerPort: {{ .Values.server.prometheus.jmx.port }}
+              containerPort: {{ .Values.server2.prometheus.jmx.port }}
           resources:
-            {{- toYaml .Values.server.prometheus.jmx.resources | nindent 12 }}
+            {{- toYaml .Values.server2.prometheus.jmx.resources | nindent 12 }}
           volumeMounts:
             - name: jmx-config
               mountPath: /etc/jmx-config
         {{- end }}
       restartPolicy: Always
-      serviceAccountName: {{ include "pinot.server.serviceAccountName" . }}
-      terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "pinot.server2.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.server2.terminationGracePeriodSeconds }}
       volumes:
         - name: config
           configMap:
-            name: {{ include "pinot.server.fullname" . }}-config
+            name: {{ include "pinot.server2.fullname" . }}-config
         - name: jmx-config
           configMap:
-            name: {{ include "pinot.server.fullname" . }}-jmx-config
+            name: {{ include "pinot.server2.fullname" . }}-jmx-config
         - name: log-config
           configMap:
-            name: {{ include "pinot.server.fullname" . }}-log-config
-        {{- if not .Values.server.persistence.enabled }}
+            name: {{ include "pinot.server2.fullname" . }}-log-config
+        {{- if not .Values.server2.persistence.enabled }}
         - name: pinot-server-storage
           emptyDir: {}
-        {{- end }}
-        {{- if .Values.server.mountTmpFS }}
-        - name: pinot-tmpfs
-          emptyDir:
-            medium: Memory
         {{- end }}
         {{- if eq .Values.cluster.storage.scheme "gs" }}
         - name: gcs-iam-secret
           secret:
             secretName: {{ .Values.cluster.storage.gs.secretName }}
         {{- end }}
+        {{- if .Values.server2.mountTmpFS }}
+        - name: pinot-tmpfs
+          emptyDir:
+            medium: Memory
+        {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.nodeSelector }}
+      {{- with .Values.server2.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.affinity }}
+      {{- with .Values.server2.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.tolerations }}
+      {{- with .Values.server2.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.securityContext }}
+      {{- with .Values.server2.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if .Values.server.persistence.enabled }}
+  {{- if .Values.server2.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: pinot-server-storage
       spec:
         accessModes:
-          - {{ .Values.server.persistence.accessMode | quote }}
-        {{- if .Values.server.persistence.storageClass }}
-        {{- if (eq "-" .Values.server.persistence.storageClass) }}
+          - {{ .Values.server2.persistence.accessMode | quote }}
+        {{- if .Values.server2.persistence.storageClass }}
+        {{- if (eq "-" .Values.server2.persistence.storageClass) }}
         storageClassName: ""
         {{- else }}
-        storageClassName: {{ .Values.server.persistence.storageClass }}
+        storageClassName: {{ .Values.server2.persistence.storageClass }}
         {{- end }}
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.server.persistence.size }}
+            storage: {{ .Values.server2.persistence.size }}
   {{- end }}
 {{- end }}

--- a/helm/templates/server2/tags.yaml
+++ b/helm/templates/server2/tags.yaml
@@ -1,0 +1,56 @@
+{{- if and .Values.server2.enabled .Values.server2.tags }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "pinot.server2.fullname" . }}-tags
+  labels:
+    app: {{ include "pinot.name" . }}
+    chart: {{ include "pinot.chart" . }}
+    component: {{ .Values.server2.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook-weight: "100"
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  activeDeadlineSeconds: 600
+  backoffLimit: 100
+  ttlSecondsAfterFinished: 900
+  template:
+    metadata:
+      name: {{ include "pinot.server2.fullname" . }}-tags
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "pinot.server2.serviceAccountName" . }}
+      containers:
+        - name: {{ include "pinot.server2.fullname" . }}-tags
+          image: curlimages/curl:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              finish() {
+                code=$?
+                curl -s -XPOST http://127.0.0.1:15020/quitquitquit
+                exit $code
+              }
+              trap finish EXIT
+              until curl -s --head localhost:15000; do echo "$(date) waiting for sidecar"; sleep 3; done
+              until [ "$(curl -s --head --connect-timeout 3 -o /dev/null -w '%{http_code}\n' 'http://{{ include "pinot.controller.fullname" . }}-svc:{{ int .Values.controller.service.port }}/')" == "200" ]; do
+                echo "$(date) waiting for {{ include "pinot.controller.fullname" . }} service"
+                sleep 3
+              done
+              sleep 5
+
+              i=0
+              while [ $i -lt {{ int .Values.server2.replicaCount }} ]; do
+                HTTP_CODE=$(curl -s -o /tmp/out -w '%{http_code}\n' -X PUT -H 'Content-Type: application/json' -H 'Accept: application/json' "http://{{ include "pinot.controller.fullname" . }}-svc:{{ int .Values.controller.service.port }}/instances/Server_{{ include "pinot.server2.fullname" . }}-${i}.{{ include "pinot.server2.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local_{{ int .Values.server2.ports.netty }}/updateTags?tags={{ join "," .Values.server2.tags }}")
+                cat /tmp/out; rm /tmp/out; echo
+                echo $HTTP_CODE
+                if [ $HTTP_CODE -lt 200 -o $HTTP_CODE -gt 299 ]; then
+                  exit 1
+                fi
+                i=$(expr $i + 1)
+              done
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -474,6 +474,117 @@ server:
   logging:
     level: info
 
+  mountTmpFS: false
+  tags: []
+
+server2:
+  name: server2
+  enabled: false
+
+  ports:
+    netty: 8098
+    admin: 8097
+
+  replicaCount: 1
+
+  dataDir: /var/pinot/server/data/index
+  segmentTarDir: /var/pinot/server/data/segment
+
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 2Gi
+    mountPath: /var/pinot/server/data
+    storageClass: "standard"
+
+  jvmOpts: "-Xms128M -Xmx320M"
+
+  log4j2ConfFile: /opt/pinot/conf/pinot-server-log4j2.xml
+  pluginsDir: /opt/pinot/plugins
+
+  service:
+    annotations: {}
+    clusterIP: ""
+    externalIPs: []
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    type: ClusterIP
+    nodePort: ""
+
+  resources:
+    requests:
+      cpu: "0.1"
+      memory: 400Mi
+
+  podLabels: {}
+
+  podAnnotations: {}
+
+  updateStrategy:
+    type: RollingUpdate
+
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+
+  readinessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+
+  nodeSelector: {}
+
+  affinity: {}
+
+  tolerations: []
+
+  securityContext: {}
+
+  serviceAccount:
+    create: true
+    name: ""
+    annotations: {}
+
+  terminationGracePeriodSeconds: 60
+
+  servicemonitor:
+    enabled: false
+    interval: 15s
+    secure: false
+    tlsConfig: {}
+
+  podDisruptionBudget:
+    enabled: false
+    maxUnavailable: 1
+    minAvailable: ""
+
+  jmx:
+    enabled: false
+    port: 7022
+    opts: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.port=7022 -Dcom.sun.management.jmxremote.rmi.port=7022 -Djava.rmi.server.hostname=127.0.0.1"
+
+  prometheus:
+    jmx:
+      enabled: false
+      port: 7071
+      image:
+        repository: solsson/kafka-prometheus-jmx-exporter@sha256
+        tag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+        pullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: "0.25"
+          memory: "256Mi"
+
+  logging:
+    level: info
+
+  mountTmpFS: false
+  tags: []
+
 servicemanager:
   name: servicemanager
   enabled: false

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,6 +21,9 @@ controller:
   port: 9000
   replicaCount: 1
 
+  retention:
+    frequencyInSeconds: 21600
+
   vip:
     enabled: false
 


### PR DESCRIPTION
- New statefulset for adding different class of servers.
- Added post-install job for tagging servers.
- Added support for mounting tmpfs.
- Updated config to add `pinot.query.scheduler.query_worker_threads` and `pinot.query.scheduler.query_runner_threads`