### PR TITLE
add flag to enable PrometheusRule

### DIFF
--- a/helm/templates/controller/prometheusrules.yaml
+++ b/helm/templates/controller/prometheusrules.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule" }}
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule") (.Values.controller.prometheus.jmx.enabled) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

Prometheus rule was enabled whenever the Cabapability was present on cluster. However sometimes we want more granular control to disable prometheus rule if we dont want to enable prometheus in first place therefore i see the connection with the flag.


### Testing
Locally tried `helm template`

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

