### PR TITLE
Updating gcloud libraries to fix underlying issue with api's with CMEK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest AS builder
 
 ARG PINOT_VERSION=0.7.1
 ARG JITPACK_REPO=hypertrace/incubator-pinot
-ARG JITPACK_TAG=hypertrace-0.7.1-11
+ARG JITPACK_TAG=hypertrace-0.7.1-12
 
 ENV PINOT_HOME=/opt/pinot
 


### PR DESCRIPTION
Fixes: https://github.com/apache/pinot/issues/8075
```
2022/03/15 12:19:03.217 ERROR [LLCSegmentCompletionHandlers] [grizzly-http-server-21] Caught exception while uploading segment: domainEventView__0__0__20220315T0540Z from instance: Server_pinot-server-2.pinot-server.traceable.svc.cluster.local_8098
com.google.cloud.storage.StorageException: 400 Bad Request
{
  "error": {
    "code": 400,
    "message": "Bad Cloud KMS crypto key: projects/dataservices-0001/locations/europe-west3/keyRings/saas-eu/cryptoKeys/saas-eu-gcs-crypto-key/cryptoKeyVersions/1",
    "errors": [
      {
        "message": "Bad Cloud KMS crypto key: projects/dataservices-0001/locations/europe-west3/keyRings/saas-eu/cryptoKeys/saas-eu-gcs-crypto-key/cryptoKeyVersions/1",
        "domain": "global",
        "reason": "invalid"
      }
    ]
  }
}
```

Cherry picked from this PR: https://github.com/apache/pinot/pull/8121

hypertrace/incubator-pinot release - https://github.com/hypertrace/incubator-pinot/releases/tag/hypertrace-0.7.1-12