### PR TITLE
fix: adds group.id as part of stream config

### DIFF
--- a/pinot-servicemanager/schemas/backendEntityView-tableConfigFile.json
+++ b/pinot-servicemanager/schemas/backendEntityView-tableConfigFile.json
@@ -16,6 +16,7 @@
   },
   "tableIndexConfig": {
     "streamConfigs": {
+      "group.id": "backendEntityView",
       "streamType": "kafka",
       "stream.kafka.consumer.type": "LowLevel",
       "stream.kafka.decoder.class.name": "org.hypertrace.pinot.plugins.GenericAvroMessageDecoder",

--- a/pinot-servicemanager/schemas/logEventView-tableConfigFile.json
+++ b/pinot-servicemanager/schemas/logEventView-tableConfigFile.json
@@ -16,6 +16,7 @@
   },
   "tableIndexConfig": {
     "streamConfigs": {
+      "group.id": "logEventView",
       "streamType": "kafka",
       "stream.kafka.consumer.type": "LowLevel",
       "stream.kafka.decoder.class.name": "org.hypertrace.pinot.plugins.GenericAvroMessageDecoder",

--- a/pinot-servicemanager/schemas/rawServiceView-tableConfigFile.json
+++ b/pinot-servicemanager/schemas/rawServiceView-tableConfigFile.json
@@ -16,6 +16,7 @@
   },
   "tableIndexConfig": {
     "streamConfigs": {
+      "group.id": "rawServiceView",
       "streamType": "kafka",
       "stream.kafka.consumer.type": "LowLevel",
       "stream.kafka.decoder.class.name": "org.hypertrace.pinot.plugins.GenericAvroMessageDecoder",

--- a/pinot-servicemanager/schemas/rawTraceView-tableConfigFile.json
+++ b/pinot-servicemanager/schemas/rawTraceView-tableConfigFile.json
@@ -16,6 +16,7 @@
   },
   "tableIndexConfig": {
     "streamConfigs": {
+      "group.id": "rawTraceView",
       "streamType": "kafka",
       "stream.kafka.consumer.type": "LowLevel",
       "stream.kafka.decoder.class.name": "org.hypertrace.pinot.plugins.GenericAvroMessageDecoder",

--- a/pinot-servicemanager/schemas/serviceCallView-tableConfigFile.json
+++ b/pinot-servicemanager/schemas/serviceCallView-tableConfigFile.json
@@ -16,6 +16,7 @@
   },
   "tableIndexConfig": {
     "streamConfigs": {
+      "group.id": "serviceCallView",
       "streamType": "kafka",
       "stream.kafka.consumer.type": "LowLevel",
       "stream.kafka.decoder.class.name": "org.hypertrace.pinot.plugins.GenericAvroMessageDecoder",

--- a/pinot-servicemanager/schemas/spanEventView-tableConfigFile.json
+++ b/pinot-servicemanager/schemas/spanEventView-tableConfigFile.json
@@ -16,6 +16,7 @@
   },
   "tableIndexConfig": {
     "streamConfigs": {
+      "group.id": "spanEventView",
       "streamType": "kafka",
       "stream.kafka.consumer.type": "LowLevel",
       "stream.kafka.decoder.class.name": "org.hypertrace.pinot.plugins.GenericAvroMessageDecoder",


### PR DESCRIPTION
With the latest pinot image, if the default group id is null, it doesn't report offset. So, adding group.id for table config schema.