### PR TITLE
add grpc and admin ports to pinot server service

### DIFF
--- a/helm/templates/broker/service-external.yaml
+++ b/helm/templates/broker/service-external.yaml
@@ -12,8 +12,10 @@ metadata:
 spec:
   type: {{ .Values.broker.external.type }}
   ports:
-    - name: external-broker
+    - name: http-broker
       port: {{ .Values.broker.external.port }}
+      protocol: TCP
+      targetPort: http-broker
   selector:
     app: {{ include "pinot.name" . }}
     release: {{ .Release.Name }}

--- a/helm/templates/broker/service-headless.yaml
+++ b/helm/templates/broker/service-headless.yaml
@@ -12,7 +12,10 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - port: {{ .Values.broker.service.port }}
+    - name: http-broker
+      port: {{ .Values.broker.service.port }}
+      protocol: TCP
+      targetPort: http-broker
   selector:
     app: {{ include "pinot.name" . }}
     release: {{ .Release.Name }}

--- a/helm/templates/broker/service.yaml
+++ b/helm/templates/broker/service.yaml
@@ -12,11 +12,15 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: request
+    - name: http-broker
       port: {{ .Values.broker.service.port }}
+      protocol: TCP
+      targetPort: http-broker
     {{- if .Values.broker.prometheus.jmx.enabled }}
     - name: http-metrics
       port: {{ .Values.broker.prometheus.jmx.port }}
+      protocol: TCP
+      targetPort: http-metrics
     {{- end }}
   selector:
     app: {{ include "pinot.name" . }}

--- a/helm/templates/broker/statefulset.yml
+++ b/helm/templates/broker/statefulset.yml
@@ -46,7 +46,7 @@ spec:
             - name: JAVA_OPTS
               value: "{{ .Values.broker.jvmOpts }} -Dlog4j2.configurationFile={{ .Values.broker.log4j2ConfFile }} -Dplugins.dir={{ .Values.broker.pluginsDir }} -Djute.maxbuffer=4194304 {{ if .Values.broker.jmx.enabled }}{{ .Values.broker.jmx.opts }}{{ end }}"
           ports:
-            - name: request
+            - name: http-broker
               containerPort: {{ .Values.broker.port }}
               protocol: TCP
             {{- if .Values.broker.jmx.enabled }}

--- a/helm/templates/controller/service-headless.yaml
+++ b/helm/templates/controller/service-headless.yaml
@@ -11,8 +11,10 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - name: rest
+    - name: http-controller
       port: {{ .Values.controller.service.port }}
+      protocol: TCP
+      targetPort: http-controller
   selector:
     app: {{ include "pinot.name" . }}
     release: {{ .Release.Name }}

--- a/helm/templates/controller/service.yaml
+++ b/helm/templates/controller/service.yaml
@@ -12,11 +12,15 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: rest
+    - name: http-controller
       port: {{ .Values.controller.service.port }}
+      protocol: TCP
+      targetPort: http-controller
     {{- if .Values.controller.prometheus.jmx.enabled }}
     - name: http-metrics
       port: {{ .Values.controller.prometheus.jmx.port }}
+      protocol: TCP
+      targetPort: http-metrics
     {{- end }}
   selector:
     app: {{ include "pinot.name" . }}

--- a/helm/templates/controller/statefulset.yaml
+++ b/helm/templates/controller/statefulset.yaml
@@ -70,7 +70,7 @@ spec:
             - name: JAVA_OPTS
               value: "{{ .Values.controller.jvmOpts }} -Dlog4j2.configurationFile={{ .Values.controller.log4j2ConfFile }} -Dplugins.dir={{ .Values.controller.pluginsDir }} -Djute.maxbuffer=4194304 {{ if .Values.controller.jmx.enabled }}{{ .Values.controller.jmx.opts }}{{ end }}"
           ports:
-            - name: rest
+            - name: http-controller
               containerPort: {{ .Values.controller.port }}
               protocol: TCP
             {{- if .Values.controller.jmx.enabled }}

--- a/helm/templates/minion/service-headless.yaml
+++ b/helm/templates/minion/service-headless.yaml
@@ -12,7 +12,10 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - port: {{ .Values.minion.service.port }}
+    - name: http-minion
+      port: {{ .Values.minion.service.port }}
+      protocol: TCP
+      targetPort: http-minion
   selector:
     app: {{ include "pinot.name" . }}
     release: {{ .Release.Name }}

--- a/helm/templates/minion/service.yaml
+++ b/helm/templates/minion/service.yaml
@@ -12,11 +12,15 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: request
+    - name: http-minion
       port: {{ .Values.minion.service.port }}
+      protocol: TCP
+      targetPort: http-minion
     {{- if .Values.minion.prometheus.jmx.enabled }}
     - name: http-metrics
       port: {{ .Values.minion.prometheus.jmx.port }}
+      protocol: TCP
+      targetPort: http-metrics
     {{- end }}
   selector:
     app: {{ include "pinot.name" . }}

--- a/helm/templates/minion/statefulset.yml
+++ b/helm/templates/minion/statefulset.yml
@@ -46,7 +46,7 @@ spec:
             - name: JAVA_OPTS
               value: "{{ .Values.minion.jvmOpts }} -Dlog4j2.configurationFile={{ .Values.minion.log4j2ConfFile }} -Dplugins.dir={{ .Values.minion.pluginsDir }} -Djute.maxbuffer=4194304 {{ if .Values.minion.jmx.enabled }}{{ .Values.minion.jmx.opts }}{{ end }}"
           ports:
-            - name: request
+            - name: http-minion
               containerPort: {{ .Values.minion.port }}
               protocol: TCP
             {{- if .Values.minion.jmx.enabled }}

--- a/helm/templates/server/configmap.yaml
+++ b/helm/templates/server/configmap.yaml
@@ -24,6 +24,8 @@ data:
   pinot-server.conf: |-
     pinot.server.netty.port={{ $tier.ports.netty }}
     pinot.server.adminapi.port={{ $tier.ports.admin }}
+    pinot.server.grpc.port={{ $tier.ports.grpc }}
+    pinot.server.grpc.enable=true
     pinot.server.instance.dataDir={{ $tier.dataDir }}
     pinot.server.instance.segmentTarDir={{ $tier.segmentTarDir }}
     pinot.set.instance.id.to.hostname=true

--- a/helm/templates/server/service-headless.yaml
+++ b/helm/templates/server/service-headless.yaml
@@ -26,8 +26,18 @@ spec:
   clusterIP: None
   publishNotReadyAddresses: true
   ports:
-    - name: request
+    - name: http-netty
       port: {{ $tier.ports.netty }}
+      protocol: TCP
+      targetPort: http-netty
+    - name: http-admin
+      port: {{ $tier.ports.admin }}
+      protocol: TCP
+      targetPort: http-admin
+    - name: grpc
+      port: {{ $tier.ports.grpc }}
+      protocol: TCP
+      targetPort: grpc
   selector:
     app: {{ include "pinot.name" $ }}
     release: {{ $.Release.Name }}

--- a/helm/templates/server/service-headless.yaml
+++ b/helm/templates/server/service-headless.yaml
@@ -26,10 +26,10 @@ spec:
   clusterIP: None
   publishNotReadyAddresses: true
   ports:
-    - name: http-netty
+    - name: request
       port: {{ $tier.ports.netty }}
       protocol: TCP
-      targetPort: http-netty
+      targetPort: request
     - name: http-admin
       port: {{ $tier.ports.admin }}
       protocol: TCP

--- a/helm/templates/server/service.yaml
+++ b/helm/templates/server/service.yaml
@@ -23,11 +23,23 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: request
+    - name: http-netty
       port: {{ $tier.ports.netty }}
+      protocol: TCP
+      targetPort: http-netty
+    - name: http-admin
+      port: {{ $tier.ports.admin }}
+      protocol: TCP
+      targetPort: http-admin
+    - name: grpc
+      port: {{ $tier.ports.grpc }}
+      protocol: TCP
+      targetPort: grpc
     {{- if $tier.prometheus.jmx.enabled }}
     - name: http-metrics
       port: {{ $tier.prometheus.jmx.port }}
+      protocol: TCP
+      targetPort: http-metrics
     {{- end }}
   selector:
     app: {{ include "pinot.name" $ }}

--- a/helm/templates/server/service.yaml
+++ b/helm/templates/server/service.yaml
@@ -23,10 +23,10 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http-netty
+    - name: request
       port: {{ $tier.ports.netty }}
       protocol: TCP
-      targetPort: http-netty
+      targetPort: request
     - name: http-admin
       port: {{ $tier.ports.admin }}
       protocol: TCP

--- a/helm/templates/server/statefulset.yml
+++ b/helm/templates/server/statefulset.yml
@@ -68,7 +68,7 @@ spec:
             - name: JAVA_OPTS
               value: "{{ $tier.jvmOpts }} -Dlog4j2.configurationFile={{ $tier.log4j2ConfFile }} -Dplugins.dir={{ $tier.pluginsDir }} -Djute.maxbuffer=4194304  {{ if $tier.jmx.enabled }}{{ $tier.jmx.opts }}{{ end }}"
           ports:
-            - name: http-netty
+            - name: request
               containerPort: {{ $tier.ports.netty }}
               protocol: TCP
             - name: http-admin

--- a/helm/templates/server/statefulset.yml
+++ b/helm/templates/server/statefulset.yml
@@ -68,11 +68,14 @@ spec:
             - name: JAVA_OPTS
               value: "{{ $tier.jvmOpts }} -Dlog4j2.configurationFile={{ $tier.log4j2ConfFile }} -Dplugins.dir={{ $tier.pluginsDir }} -Djute.maxbuffer=4194304  {{ if $tier.jmx.enabled }}{{ $tier.jmx.opts }}{{ end }}"
           ports:
-            - name: request
+            - name: http-netty
               containerPort: {{ $tier.ports.netty }}
               protocol: TCP
-            - name: admin
+            - name: http-admin
               containerPort: {{ $tier.ports.admin }}
+              protocol: TCP
+            - name: grpc
+              containerPort: {{ $tier.ports.grpc }}
               protocol: TCP
             {{- if $tier.jmx.enabled }}
             - name: jmx

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -387,6 +387,7 @@ server:
   ports:
     netty: 8098
     admin: 8097
+    grpc: 8090
 
   replicaCount: 1
 


### PR DESCRIPTION
In order to support large data scanning, Pinot [0.6.0, 0.10.0] introduces a gRPC server for on-demand data scanning with a reasonably smaller memory footprint.
You can enable it by adding the below configs to the Pinot server config file:
```
pinot.server.grpc.enable=true
pinot.server.grpc.port=8090
```
